### PR TITLE
Fix schema validation #16, #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The JSON Schema is more strict and should not have issues with missing required fields in Collections any longer [#3](https://github.com/stac-extensions/processing/issues/3)
+- The JSON Schema is more strict and should not have issues with missing required fields in Collections any longer [#3](https://github.com/stac-extensions/processing/issues/3), [#8](https://github.com/stac-extensions/processing/issues/8), [#16](https://github.com/stac-extensions/processing/issues/16)
 
 ## [v1.0.0] - 2021-03-08
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ and therefore are shared across all items, it is recommended adding the fields t
 
 These fields can be used in a variety of places:
 
-For Items:
-- The fields are placed in the properties.
-- Additionally, STAC allows all fields to be used in the Asset Object.
+1. Items:
+   - The fields are placed in the properties. At least one field is required to be present.
+   - Additionally, STAC allows all fields to be used in the Asset Object.
 
-For Collections:
-- The fields are usually placed in the [Provider Objects](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object)
-for the `providers` that have the role `producer` or `processor` assigned. They don't need to be provided for all providers of the respective role.
-- The fields can also be used in summaries, assets or Item asset definitions.
-
-If the extension is given in the `stac_extensions` list, at least one of the fields must be specified in any of the given places listed above.
-Please note that the JSON Schema might not be able to validate this requirement in all cases due to limitations in JSON Schema.
+2. Collections:
+   - The fields are usually placed in the [Provider Objects](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object)
+     for the `providers` that have the role `producer` or `processor` assigned.
+     They don't need to be provided for all providers of the respective role.
+   - The fields can also be used in `summaries`, Collection `assets` or Item asset definitions (`item_assets`).
+    
+   If the extension is given in the `stac_extensions` list, at least one of the fields must be specified in any of the given places listed above.
+   Please note that the JSON Schema is not be able to validate the values of Collection summaries.
 
 ### Processing Date Time
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -5,65 +5,81 @@
   "description": "STAC Processing Extension for STAC Items and STAC Collections.",
   "anyOf": [
     {
-      "$comment": "This is the schema for STAC Items. Remove this object if this extension only applies to Collections.",
+      "$comment": "This is the schema for STAC Items.",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "assets"
+      ],
+      "properties": {
+        "type": {
+          "const": "Feature"
+        },
+        "properties": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/require_any_field"
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
+        },
+        "assets": {
+          "$comment": "This validates the fields in Item Assets, but does not require them.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
+        }
+      },
       "allOf": [
         {
           "$ref": "#/definitions/stac_extensions"
-        },
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "properties",
-            "assets"
-          ],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
-            "properties": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/require_any_field"
-                },
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
-            },
-            "assets": {
-              "$comment": "This validates the fields in Item Assets, but does not require them.",
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
-              }
-            }
-          }
         }
       ]
     },
     {
       "$comment": "This is the schema for STAC Collections.",
       "type": "object",
-      "allOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "const": "Collection"
-            }
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "Collection"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fields"
           }
         },
+        "item_assets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
+        },
+        "summaries": {
+          "$comment": "The values of summaries are not validated yet!"
+        },
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
+        }
+      },
+      "allOf": [
         {
           "$ref": "#/definitions/stac_extensions"
         }
       ],
       "anyOf": [
         {
-          "$comment": "Validate fields in Collection Providers.",
+          "$comment": "Requires at least one provider to contain processing fields.",
           "type": "object",
           "required": [
             "providers"
@@ -71,42 +87,28 @@
           "properties": {
             "providers": {
               "type": "array",
-              "minItems": 1,
-              "items": {
+              "contains": {
                 "type": "object",
-                "oneOf": [
+                "allOf": [
                   {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "roles"
-                        ],
-                        "properties": {
-                          "roles": {
-                            "type": "array",
-                            "contains": {
-                              "enum": [
-                                "producer",
-                                "processor"
-                              ]
-                            }
-                          }
+                    "type": "object",
+                    "required": [
+                      "roles"
+                    ],
+                    "properties": {
+                      "roles": {
+                        "type": "array",
+                        "contains": {
+                          "enum": [
+                            "producer",
+                            "processor"
+                          ]
                         }
-                      },
-                      {
-                        "$ref": "#/definitions/require_any_field"
-                      },
-                      {
-                        "$ref": "#/definitions/fields"
                       }
-                    ]
+                    }
                   },
                   {
-                    "patternProperties": {
-                      "^(?!processing:)": {}
-                    },
-                    "additionalProperties": false
+                    "$ref": "#/definitions/require_any_field"
                   }
                 ]
               }
@@ -114,8 +116,8 @@
           }
         },
         {
+          "$comment": "Requires at least one asset to contain processing fields.",
           "type": "object",
-          "$comment": "This validates the fields in Collection Assets, but does not require them.",
           "required": [
             "assets"
           ],
@@ -125,14 +127,7 @@
               "not": {
                 "additionalProperties": {
                   "not": {
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/require_any_field"
-                      },
-                      {
-                        "$ref": "#/definitions/fields"
-                      }
-                    ]
+                    "$ref": "#/definitions/require_any_field"
                   }
                 }
               }
@@ -140,8 +135,8 @@
           }
         },
         {
+          "$comment": "Requires at least one item asset definition to contain processing fields.",
           "type": "object",
-          "$comment": "This is the schema for the fields in Item Asset Definitions. It doesn't require any fields.",
           "required": [
             "item_assets"
           ],
@@ -151,14 +146,7 @@
               "not": {
                 "additionalProperties": {
                   "not": {
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/require_any_field"
-                      },
-                      {
-                        "$ref": "#/definitions/fields"
-                      }
-                    ]
+                    "$ref": "#/definitions/require_any_field"
                   }
                 }
               }
@@ -167,7 +155,7 @@
         },
         {
           "type": "object",
-          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existance of the properties, but not the schema of the summaries.",
+          "$comment": "Requires at least one summary to be a processing field.",
           "required": [
             "summaries"
           ],
@@ -195,8 +183,24 @@
         }
       }
     },
+    "require_provider_role": {
+      "type": "object",
+      "required": [
+        "roles"
+      ],
+      "properties": {
+        "roles": {
+          "type": "array",
+          "contains": {
+            "enum": [
+              "producer",
+              "processor"
+            ]
+          }
+        }
+      }
+    },
     "require_any_field": {
-      "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
       "anyOf": [
         {"type": "object", "required": ["processing:expression"]},
         {"type": "object", "required": ["processing:lineage"]},
@@ -206,7 +210,6 @@
       ]
     },
     "fields": {
-      "$comment": "Add your new fields here. Don't require them here, do that above in the corresponding schema.",
       "type": "object",
       "properties": {
         "processing:expression": {


### PR DESCRIPTION
- Fixes JSON Schema to check providers properly #8
- Fixes JSON Schema to check field requirements properly and everywhere (except summaries, as mentioned in the docs) #16
- Clarifies that Items are required to contain one processing field.

I made quite a number of tests to check that the JSON Schema works in different scenarios and couldn't find any issues.

May supersede a couple of existing PRs (#6, #9) as I think the JSON Schemas in those PRs don't fully capture all issues and it could avoid the unit tests, it seems better to have tests in JSON Schemas so that other tooling (PySTAC, validators) can make use of it. @l0b0 

I hope that we can release a 1.1.0 of the extension after this has been merged.