### PR TITLE
fix: Use specific action versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - uses: actions/checkout@v3.0.2
       - name: deploy JSON Schema for version ${{ env.GITHUB_REF_SLUG }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: json-schema

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Inject env variables
         uses: rlespinasse/github-slug-action@v3.x
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - name: deploy JSON Schema for version ${{ env.GITHUB_REF_SLUG }}
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inject env variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v3.6.1
       - uses: actions/checkout@v3.0.2
       - name: deploy JSON Schema for version ${{ env.GITHUB_REF_SLUG }}
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3.4.1
         with:
           node-version: 'lts/*'
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - run: |
           npm install
           npm test


### PR DESCRIPTION
GitHub Actions unfortunately runs the *latest* version of the actions which fits the `uses` directive version. So right now `actions/checkout@v3` is equivalent to `actions/checkout@v3.0.2`, but this can change at any time. To avoid workflows suddenly failing in case a new minor/patch version of an action, this PR uses the most specific version number available for the checkout action.