### PR TITLE
Add tiling object example and description in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ and therefore are shared across all items, it is recommended adding the fields t
 
 - Examples:
   - [Item example](examples/item.json): Shows the basic usage of the extension in a STAC Item
-  - [Collection example](examples/collection.json): Shows the basic usage of the extension in a STAC Collection
+  - [Collection example](examples/collection.json): Shows the basic usage of the extension in a STAC
+  - Collection example with tiling object:
+    - [`collection-modis-landcover-houston.json`](./examples/collection-modis-landcover-houston.json)
 - [JSON Schema](json-schema/schema.json)
 - [Changelog](./CHANGELOG.md)
 
@@ -88,6 +90,9 @@ Potential expression formats with examples:
 | `gdal-calc` | string | A [`gdal_calc.py`](https://gdal.org/programs/gdal_calc.html) expression based on numpy syntax. | `A*logical_or(A<=177,A>=185)` |
 | `openeo`    | object | [openEO process](https://openeo.org/documentation/1.0/developers/api/reference.html#section/Processes) | [Example](https://raw.githubusercontent.com/Open-EO/openeo-processes/1.2.0/normalized_difference.json) |
 | `rio-calc`  | string | A [rio-calc](https://rasterio.readthedocs.io/en/latest/topics/calc.html) (RasterIO) expression | `(b4-b1)/(b4+b1)` |
+| `tiling` | object | key value pairs describing how to tile the data, for example `{ "colormap": "viridis", "rescale": [0,1], "resampling": "nearest" }`. See [`collection-modis-landcover-houston.json`](./examples/collection-modis-landcover-houston.json) for an example. |
+
+[titiler](https://github.com/developmentseed/titiler/) is an example dynamic tiling application but the tiling object should be generic enough to be used with other tile servers.
 
 ## Relation types
 

--- a/examples/collection-modis-landcover-houston.json
+++ b/examples/collection-modis-landcover-houston.json
@@ -1,0 +1,179 @@
+{
+  "id": "landcover_Z_f_2019_cog",
+  "bbox": [
+    -95.99531873393823,
+    29.07716802830657,
+    -94.29534689027045,
+    30.39936449861516
+  ],
+  "type": "Feature",
+  "links": [
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover/items/landcover_Z_f_2019_cog"
+    }
+  ],
+  "assets": {
+    "cog_default": {
+      "href": "s3://veda-data-store-staging/houston-landcover/landcover_Z_f_2019_cog.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data",
+        "layer"
+      ],
+      "title": "Default COG Layer",
+      "description": "Cloud optimized default layer to display on map",
+      "raster:bands": [
+        {
+          "scale": 1,
+          "nodata": -999,
+          "offset": 0,
+          "sampling": "area",
+          "data_type": "float32",
+          "histogram": {
+            "max": 95,
+            "min": 11,
+            "count": 11,
+            "buckets": [
+              92542,
+              221312,
+              3652,
+              107193,
+              11793,
+              0,
+              0,
+              19862,
+              249362,
+              150800
+            ]
+          },
+          "statistics": {
+            "mean": 54.547851995759565,
+            "stddev": 30.797947880218707,
+            "maximum": 95,
+            "minimum": 11,
+            "valid_percent": 91.61461185651699
+          }
+        }
+      ]
+    }
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -95.99531873393823,
+          29.07716802830657
+        ],
+        [
+          -94.29534689027045,
+          29.07716802830657
+        ],
+        [
+          -94.29534689027045,
+          30.39936449861516
+        ],
+        [
+          -95.99531873393823,
+          30.39936449861516
+        ],
+        [
+          -95.99531873393823,
+          29.07716802830657
+        ]
+      ]
+    ]
+  },
+  "collection": "houston-landcover",
+  "properties": {
+    "datetime": "2019-01-01T00:00:00+00:00",
+    "proj:bbox": [
+      -10686150,
+      3364710,
+      -10496910,
+      3533370
+    ],
+    "proj:epsg": 3395,
+    "proj:shape": [
+      5622,
+      6308
+    ],
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -10686150,
+            3364710
+          ],
+          [
+            -10496910,
+            3364710
+          ],
+          [
+            -10496910,
+            3533370
+          ],
+          [
+            -10686150,
+            3533370
+          ],
+          [
+            -10686150,
+            3364710
+          ]
+        ]
+      ]
+    },
+    "proj:transform": [
+      30,
+      0,
+      -10686150,
+      0,
+      -30,
+      3533370,
+      0,
+      0,
+      1
+    ]
+  },
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "virtual:assets": {
+    "default_tiles": {
+      "href": [
+        "#cog_default"
+      ],
+      "title": "Default Tiles",
+      "processing:expression": {
+        "format": "tiling",
+        "expression": {
+          "rescale": [-215,215],
+          "resampling": "bilinear",
+          "colormap_name": "rdbu_r",
+          "bidx": 1
+        }
+      }
+    }
+  }
+}

--- a/examples/collection-modis-landcover-houston.json
+++ b/examples/collection-modis-landcover-houston.json
@@ -171,7 +171,7 @@
           "rescale": [-215,215],
           "resampling": "bilinear",
           "colormap_name": "rdbu_r",
-          "bidx": 1
+          "bidx": [1]
         }
       }
     }


### PR DESCRIPTION
Adds `tiling` as an optional value for the format of `processing:expression`. Also adds a collection example and description in the README.

